### PR TITLE
Fix builds on FreeBSD, remove duplicate mention of switch

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,4 +11,4 @@ target_include_directories(${PROJECT_NAME} PRIVATE include deps/parsing/include)
 
 add_subdirectory(deps/parsing)
 
-target_link_libraries(${PROJECT_NAME} PRIVATE parsing)
+target_link_libraries(${PROJECT_NAME} PRIVATE parsing pthread)

--- a/README.md
+++ b/README.md
@@ -69,8 +69,6 @@ Usage:
 
     Boolean Arguments (cont.) - Options that affect how the output is written, and also the debug options.
         `--quiet`/`-q`
-            Produce less output.
-        `--quiet`/`-q`
             Produce no output.
         `--debug`
             Show some more information regarding what happened (currently just includes thread count and more detailed


### PR DESCRIPTION
This PR fixes builds on FreeBSD by linking with libpthread.
Alongside this, I have also removed a duplicate mention of the `--quiet/-q` switch in the README.